### PR TITLE
use POST to fetch color maps

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,6 +1,6 @@
 
 importFrom(utils, download.file, head)
-importFrom(httr, GET, http_status, content, stop_for_status)
+importFrom(httr, GET, POST, http_status, content, stop_for_status)
 importFrom(png, readPNG, writePNG)
 importFrom(Biostrings, readAAStringSet, readDNAStringSet,
     DNAStringSet, AAStringSet)

--- a/inst/unitTests/test_KEGGREST.R
+++ b/inst/unitTests/test_KEGGREST.R
@@ -1,5 +1,6 @@
 library(KEGGREST)
 library(RUnit)
+library(httr)
 
 ## checker helper
 .checkLOL <- function(res)
@@ -216,12 +217,16 @@ test_mark_and_color_pathways_by_objects  <- function(){
                                  c("eco:b0002", "eco:c00263"))
   .checkCharVec(url)
   checkTrue(grep("https://", url)==1)
+  res <- GET(url)
+  checkTrue( http_type(res) == 'image/png' )
   url <- color.pathway.by.objects("path:eco00260",
                                   c("eco:b0002", "eco:c00263"),
                                   c("#ff0000", "#00ff00"),
                                   c("#ffff00", "yellow"))
   .checkCharVec(url)
   checkTrue(grep("https://", url)==1)
+  res <- GET(url)
+  checkTrue( http_type(res) == 'image/png' )
 }
 
 


### PR DESCRIPTION
Part of a manuscript stopped compiling, and the problem seems to be a URL that is too long (due to too many gene IDs being passed) in the `color.pathway.by.objects()` function. This PR attempts to fix the issue by using the same POST method used by the KEGG webserver itself, instead of encoding all of the params into a GET param string.

Tests are also added to ensure that the return URL actually links to a valid PNG.