### PR TITLE
Add function for getting compound list from pathway

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -12,6 +12,7 @@ export(
     listDatabases,
     keggFind,
     keggGet,
+    keggGetCompounds, 
     keggConv,
     keggLink,
     mark.pathway.by.objects,

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -12,7 +12,7 @@ export(
     listDatabases,
     keggFind,
     keggGet,
-    keggGetCompounds, 
+    keggCompounds,
     keggConv,
     keggLink,
     mark.pathway.by.objects,

--- a/R/KEGGREST.R
+++ b/R/KEGGREST.R
@@ -66,7 +66,7 @@ keggGet <- function(dbentries,
     .getUrl(url, .flatFileParser)
 }
 
-keggGetCompounds <- function(pathway_id)
+keggCompounds <- function(pathway_id)
 {
     url <- sprintf("%s/link/cpd/%s", .getRootUrl(), pathway_id)
     .getUrl(url, .compoundParser)
@@ -74,7 +74,7 @@ keggGetCompounds <- function(pathway_id)
 
 .keggConv <- function(target, source)
 {
-    query <-paste(source, collapse = "+") 
+    query <-paste(source, collapse = "+")
     url <- sprintf("%s/conv/%s/%s", .getRootUrl(), target, query)
     .getUrl(url, .listParser, nameColumn = 1, valueColumn = 2)
 }
@@ -98,7 +98,7 @@ keggLink <- function(target, source)
             .getRootUrl(), target, paste(source, collapse="+"))
     .getUrl(url, .listParser, nameColumn=1, valueColumn=2)
 
-    }   
+    }
     ## FIXME?? keggLink("pathway",c("hsa:10458", "ece:Z5100"))
     ## returns a list with duplicate names
 }

--- a/R/KEGGREST.R
+++ b/R/KEGGREST.R
@@ -66,6 +66,12 @@ keggGet <- function(dbentries,
     .getUrl(url, .flatFileParser)
 }
 
+keggGetCompounds <- function(pathway_id)
+{
+    url <- sprintf("%s/link/cpd/%s", .getRootUrl(), pathway_id)
+    .getUrl(url, .compoundParser)
+}
+
 .keggConv <- function(target, source)
 {
     query <-paste(source, collapse = "+") 

--- a/R/parsers.R
+++ b/R/parsers.R
@@ -315,3 +315,11 @@ flatFileRecordGen <- setRefClass("KEGGFlatFileRecord",
         }
     )
 )
+
+.compoundParser <- function(txt)
+{
+    cmptxt <- unlist(txt)
+    lines <- strsplit(cmptxt, "\n")
+    cmps <- gsub(".*cpd:", "", unlist(lines))
+    cmps
+}

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -30,7 +30,7 @@
     content <- .strip(content(response, "text"))
     if (nchar(content) == 0)
         return(character(0))
-        do.call(parser, list(content, ...))
+    do.call(parser, list(content, ...))
 }
 
 .strip <- function(str)

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -30,7 +30,7 @@
     content <- .strip(content(response, "text"))
     if (nchar(content) == 0)
         return(character(0))
-    do.call(parser, list(content, ...))
+        do.call(parser, list(content, ...))
 }
 
 .strip <- function(str)

--- a/man/keggCompounds.Rd
+++ b/man/keggCompounds.Rd
@@ -1,0 +1,30 @@
+\name{keggCompounds}
+\alias{keggCompounds}
+\title{
+Get list of compounds IDs for pathway
+}
+\description{
+Get list of compounds IDs for pathway.
+}
+\usage{
+keggCompounds(pathway_id)
+}
+\arguments{
+  \item{target}{
+  A KEGG pathway identifier with the prefix \code{map} and 5 digit number.
+}
+
+}
+\value{
+A list of KEGG compound identifiers
+}
+\references{
+  \url{https://www.genome.jp/kegg/pathway.html}
+}
+\author{
+Dan Tenenbaum
+}
+\examples{
+keggCompounds("map00361")
+}
+\keyword{ compounds }


### PR DESCRIPTION
Hi all! First off, I want to say thanks to the developers so much for this package, it's been very useful in pulling info from KEGG using R. Second, I'm not sure if this is the correct place to submit this PR as I've never contributed to a Bioconductor package before. Please let me know if there's another way to do this! 

As part of the pipeline for a project we're working on, we needed to be able to get the list of compounds for a specified KEGG pathway. As it didn't look like that was possible to do using `KEGGREST`, I added some code to do so. An example of this new function `keggGetCompounds` is below: 

```
keggGetCompounds("map00361")
 [1] "C00011" "C00042" "C00090" "C00146" "C00160"
 [6] "C00530" "C00682" "C01407" "C02124" "C02222"
[11] "C02375" "C02575" "C02625" "C02814" "C02933"
[16] "C03434" "C03572" "C03585" "C03664" "C03918"
[21] "C04091" "C04431" "C04522" "C04706" "C04729"
[26] "C05618" "C06328" "C06329" "C06594" "C06596"
[31] "C06597" "C06598" "C06599" "C06600" "C06601"
[36] "C06602" "C06603" "C06755" "C06988" "C06989"
[41] "C06990" "C07075" "C07088" "C07089" "C07090"
[46] "C07091" "C07092" "C07093" "C07094" "C07095"
[51] "C07096" "C07097" "C07098" "C07099" "C07100"
[56] "C07101" "C07102" "C07103" "C11352" "C12831"
[61] "C12832" "C12833" "C12834" "C12835" "C12836"
[66] "C12837" "C12838" "C14419" "C14450" "C16181"
[71] "C16182" "C16266" "C18236" "C18238" "C18240"
[76] "C18241" "C18242" "C18243" "C18244" "C18933"
[81] "C21103" "C21104" "C21105"
```

I wanted to see if it was possible to incorporate this into the package in case other folks could benefit from it. Let me know!