### PR TITLE
Replace http to https

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -1,7 +1,7 @@
 
 .getRootUrl <- function()
 {
-    getOption("KEGG_REST_URL", "http://rest.kegg.jp")
+    getOption("KEGG_REST_URL", "https://rest.kegg.jp")
 }
 
 .getGenomeUrl <- function()


### PR DESCRIPTION
KEGG API moved from HTTP to HTTPS on June 1, 2022. (See "Update history" in https://www.kegg.jp/kegg/rest/)
If it remains http, KEGGREST does not work well.
This will fix #7